### PR TITLE
Fix/8 GitHub actions workflow fails at cloud run deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'
         with:
-          workload_identity_provider: 'projects/794116114096/locations/global/workloadIdentityPools/gh-issues-finder/providers/github-workflows'
+          workload_identity_provider: 'projects/794116114096/locations/global/workloadIdentityPools/github/providers/github-workflows-provider'
           service_account: 'github-workflows@gh-issues-finder.iam.gserviceaccount.com'
 
       - id: deploy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: cd
 
 on:
   push:
-    #branches: [master]
+    branches: [master]
 
   workflow_dispatch:
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
 
     permissions:
       contents: 'read'
-      id-token: write
+      id-token: 'write'
 
     steps:
       - uses: actions/checkout@v3
@@ -21,16 +21,14 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: 'projects/794116114096/locations/global/workloadIdentityPools/gh-issues-finder/providers/github-workflows'
+          service_account: 'sa-gh-issue-finder@gh-issues-finder.iam.gserviceaccount.com'
 
       - id: deploy
         uses: google-github-actions/deploy-cloudrun@v0
         with:
-          service: ${{ secrets.GCP_RUN_SERVICE_NAME }}
-          region: ${{ secrets.GCP_REGION }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          #env_vars: >-
-          #    GH_AUTH_TOKEN={{ secrets.GH_AUTH_TOKEN }}
+          service: 'gh-issues-finder-backend'
+          region: 'europe-west1'
+          project_id: 'gh-issues-finder'
           flags: --allow-unauthenticated --timeout=1800
           source: .

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,14 +21,14 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'
         with:
-          workload_identity_provider: 'projects/794116114096/locations/global/workloadIdentityPools/github/providers/github-workflows-provider'
-          service_account: 'github-workflows@gh-issues-finder.iam.gserviceaccount.com'
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - id: deploy
         uses: google-github-actions/deploy-cloudrun@v0
         with:
-          service: 'gh-issues-finder-backend'
-          region: 'europe-west1'
-          project_id: 'gh-issues-finder'
+          service: ${{ secrets.GCP_RUN_SERVICE_NAME }}
+          region: ${{ secrets.GCP_REGION }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
           flags: --allow-unauthenticated --timeout=1800
           source: .

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         uses: 'google-github-actions/auth@v0'
         with:
           workload_identity_provider: 'projects/794116114096/locations/global/workloadIdentityPools/gh-issues-finder/providers/github-workflows'
-          service_account: 'sa-gh-issue-finder@gh-issues-finder.iam.gserviceaccount.com'
+          service_account: 'github-workflows@gh-issues-finder.iam.gserviceaccount.com'
 
       - id: deploy
         uses: google-github-actions/deploy-cloudrun@v0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           service: 'gh-issues-finder-backend'
           region: 'europe-west1'
-          project_id: '794116114096'
+          project_id: 'gh-issues-finder'
           flags: --allow-unauthenticated --timeout=1800
           source: .

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           service: 'gh-issues-finder-backend'
           region: 'europe-west1'
-          project_id: 'gh-issues-finder'
+          project_id: '794116114096'
           flags: --allow-unauthenticated --timeout=1800
           source: .


### PR DESCRIPTION
This fix #8 the problem was at the service account, we needed to remove secrets and use strings to identify the problem, now the secrets are back in place